### PR TITLE
DMOH-55: Fixed not sending the user-key if no value is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- DMOH-55: Fixed not sending the user-key if no value is set.
+
 ## [0.1.0] - 2019-02-27
 
 ### Updated

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -30,7 +30,9 @@ async function request(uri, format, options = {}) {
     options.headers.set('Accept', 'text/html')
   }
 
-  options.headers.append('user-key', config('endpoint_key'));
+  if (config('endpoint_key')) {
+    options.headers.set('user-key', config('endpoint_key'));
+  }
 
   return await fetch(`${options.endpoint || config('endpoint')}/${uri}`, options)
     .then(function checkStatus(response) {


### PR DESCRIPTION
This avoids preflight request if no authentication is required.

## Description

From the moment a user-key is send in the headers, browsers will send out an OPTIONS request to the service endpoint. To avoid this we don't set the user-key to the header if it does not contain any value?

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [ ] I have added/updated unit tests for changes I've made
